### PR TITLE
Corrected the command for running the server in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ Then run the following commands to bootstrap your environment.
     #Note aspell dictionary for Urdu is not yet available
 
     pip install -r requirements.txt
-    python manage.py server
+    python manage.py runserver
 
 You will see a pretty welcome screen.
 


### PR DESCRIPTION
There was a typo in the line `python manage.py server` while installing Translators Desk. 

We could even remove this line from there, since there's a `python manage.py run` right after the database setup is done.
